### PR TITLE
Suppress warning about undefined variable

### DIFF
--- a/lib/CLI/Simple.pm.in
+++ b/lib/CLI/Simple.pm.in
@@ -504,7 +504,7 @@ sub usage {
 ########################################################################
   my ($self) = @_;
 
-  my $input = $ENV{MODULINO_WRAPPER} eq 'cli-simple' ? $INC{'CLI/Simple/Shell.pm'} : $self->get__program;
+  my $input = $ENV{MODULINO_WRAPPER} // '' eq 'cli-simple' ? $INC{'CLI/Simple/Shell.pm'} : $self->get__program;
 
   pod2usage(
     -noperldoc => 1,


### PR DESCRIPTION
Testing a variable that isn't defined generates a warning, make sure we test against something.

Previously would see this warning in tests:

```
Use of uninitialized value $ENV{"MODULINO_WRAPPER"} in string eq at /build/reproducible-path/libcli-simple-perl-2.0.3/blib/lib/CLI/Simple.pm line 507.
```